### PR TITLE
Exclude the default locale when generating embedded fields

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -9,5 +9,4 @@ config :ex_cldr_trans, Cldr.Trans.Repo,
   log: false
 
 config :ex_cldr,
-  default_locale: "en-001",
   default_backend: MyApp.Cldr

--- a/lib/cldr_trans.ex
+++ b/lib/cldr_trans.ex
@@ -18,6 +18,7 @@ defmodule Cldr.Trans do
   * `:container` (optional) - name of the field that contains the embedded translations.
     Defaults to`:translations`.
   * `:default_locale` (optional) - declares the locale of the base untranslated column.
+    Defaults to the `default_locale` configured for the Cldr backend.
 
   ## Structured translations
 
@@ -26,7 +27,7 @@ defmodule Cldr.Trans do
 
       defmodule MyApp.Article do
         use Ecto.Schema
-        use Trans, translates: [:title, :body], default_locale: :en
+        use MyApp.Cldr.Trans, translates: [:title, :body]
 
         schema "articles" do
           field :title, :string
@@ -66,7 +67,7 @@ defmodule Cldr.Trans do
 
       defmodule MyApp.Article do
         use Ecto.Schema
-        use Trans, translates: [:title, :body], default_locale: :en
+        use MyApp.Cldr.Trans, translates: [:title, :body]
 
         schema "articles" do
           field :title, :string

--- a/lib/cldr_trans.ex
+++ b/lib/cldr_trans.ex
@@ -217,6 +217,7 @@ defmodule Cldr.Trans do
   end
 
   defmacro translations(field_name, translation_module, locales, options) do
+    module = __CALLER__.module
     options = Keyword.merge(Cldr.Trans.default_trans_options(), options)
     {build_field_schema, options} = Keyword.pop(options, :build_field_schema)
 
@@ -229,7 +230,9 @@ defmodule Cldr.Trans do
 
       embeds_one unquote(field_name), unquote(translation_module), unquote(options) do
         for locale_name <- List.wrap(unquote(locales)) do
-          embeds_one locale_name, Module.concat(__MODULE__, Fields), on_replace: :update
+          if locale_name != Module.get_attribute(unquote(module), :trans_default_locale) do
+            embeds_one locale_name, Module.concat(__MODULE__, Fields), on_replace: :update
+          end
         end
       end
     end

--- a/test/support/models/article.ex
+++ b/test/support/models/article.ex
@@ -31,7 +31,7 @@ defmodule Cldr.Trans.Article do
   """
 
   use Ecto.Schema
-  use Cldr.Trans, translates: [:title, :body]
+  use MyApp.Cldr.Trans, translates: [:title, :body]
 
   import Ecto.Changeset
 

--- a/test/support/models/book.ex
+++ b/test/support/models/book.ex
@@ -15,7 +15,7 @@ defmodule Cldr.Trans.Book do
   """
 
   use Ecto.Schema
-  use Cldr.Trans, translates: [:title, :body], default_locale: :en
+  use MyApp.Cldr.Trans, translates: [:title, :body]
 
   schema "articles" do
     field :title, :string

--- a/test/support/models/comment.ex
+++ b/test/support/models/comment.ex
@@ -2,7 +2,7 @@ defmodule Cldr.Trans.Comment do
   @moduledoc false
 
   use Ecto.Schema
-  use Cldr.Trans, translates: [:comment], container: :transcriptions
+  use MyApp.Cldr.Trans, translates: [:comment], container: :transcriptions
 
   import Ecto.Changeset
 

--- a/test/support/models/magazine.ex
+++ b/test/support/models/magazine.ex
@@ -1,6 +1,6 @@
 defmodule Cldr.Trans.Magazine do
   use Ecto.Schema
-  use Cldr.Trans, translates: [:title, :body], default_locale: :en
+  use MyApp.Cldr.Trans, translates: [:title, :body]
 
   schema "articles" do
     field :title, :string

--- a/test/support/myapp_cldr_backend.ex
+++ b/test/support/myapp_cldr_backend.ex
@@ -4,5 +4,4 @@ defmodule MyApp.Cldr do
     locales: ["en", "de", "ja", "en-AU", "th", "ar", "pl", "doi", "fr-CA", "nb", "no"],
     generate_docs: true,
     providers: [Cldr.Trans]
-
 end

--- a/test/support/myapp_cldr_backend.ex
+++ b/test/support/myapp_cldr_backend.ex
@@ -2,6 +2,7 @@ defmodule MyApp.Cldr do
   use Cldr,
     gettext: MyApp.Gettext,
     locales: ["en", "de", "ja", "en-AU", "th", "ar", "pl", "doi", "fr-CA", "nb", "no"],
+    default_locale: "en-001",
     generate_docs: true,
     providers: [Cldr.Trans]
 end

--- a/test/support/myapp_cldr_backend.ex
+++ b/test/support/myapp_cldr_backend.ex
@@ -2,7 +2,7 @@ defmodule MyApp.Cldr do
   use Cldr,
     gettext: MyApp.Gettext,
     locales: ["en", "de", "ja", "en-AU", "th", "ar", "pl", "doi", "fr-CA", "nb", "no"],
-    default_locale: "en-001",
+    default_locale: "en",
     generate_docs: true,
     providers: [Cldr.Trans]
 end

--- a/test/trans_test.exs
+++ b/test/trans_test.exs
@@ -24,14 +24,17 @@ defmodule Cldr.TransTest do
     assert Article.__trans__(:container) == :translations
   end
 
-  test "the default locale" do
+  test "the default locale can be set from the Cldr backend" do
+    assert Article.__trans__(:default_locale) == :en
+  end
+  
+  test "the Cldr backend's default locale can be overridden per model" do 
     defmodule Book do
-      use Trans, translates: [:title, :body], default_locale: :en
+      use Trans, translates: [:title, :body], default_locale: :fr
       defstruct title: "", body: "", translations: %{}
     end
 
-    assert Book.__trans__(:default_locale) == :en
-    assert Article.__trans__(:default_locale) == nil
+    assert Book.__trans__(:default_locale) == :fr
   end
 
   test "returns the custom translation container name if specified" do
@@ -88,7 +91,7 @@ defmodule Cldr.TransTest do
         unique: true}} =
       Cldr.Trans.Brochure.__schema__(:type, :translations)
 
-     assert [:ar, :de, :doi, :en, :"en-001", :"en-AU", :fr, :"fr-CA", :ja, :nb, :no, :pl, :th] =
+     assert [:ar, :de, :doi, :en, :"en-AU", :fr, :"fr-CA", :ja, :nb, :no, :pl, :th] =
        Cldr.Trans.Brochure.Translations.__schema__(:fields)
      assert [:title, :body] = Cldr.Trans.Brochure.Translations.Fields.__schema__(:fields)
   end

--- a/test/trans_test.exs
+++ b/test/trans_test.exs
@@ -91,7 +91,7 @@ defmodule Cldr.TransTest do
         unique: true}} =
       Cldr.Trans.Brochure.__schema__(:type, :translations)
 
-     assert [:ar, :de, :doi, :en, :"en-AU", :fr, :"fr-CA", :ja, :nb, :no, :pl, :th] =
+     assert [:ar, :de, :doi, :"en-AU", :fr, :"fr-CA", :ja, :nb, :no, :pl, :th] =
        Cldr.Trans.Brochure.Translations.__schema__(:fields)
      assert [:title, :body] = Cldr.Trans.Brochure.Translations.Fields.__schema__(:fields)
   end


### PR DESCRIPTION
This PR excludes the default locale when generating embedded fields via the `translations` macro. E.g. if `default_locale: "en"` is configured, a translatable struct could look like:

```
%Book{
  body: "informative book body",
  title: "captivating book title",
  translations: %{
    es: %{body: "...", title: "..."},
    fr: %{body: "...", title: "..."}
  }
}
```
rather than 
```
%Book{
  body: "informative book body",
  title: "captivating book title",
  translations: %{
    en: nil,
    es: %{body: "...", title: "..."},
    fr: %{body: "...", title: "..."}
  }
}
```